### PR TITLE
Deal with attempting to create a Serializer where the model doesn't exist

### DIFF
--- a/Lib/SerializerFactory.php
+++ b/Lib/SerializerFactory.php
@@ -41,10 +41,18 @@ class SerializerFactory {
 		App::uses($this->className, 'Serializer');
 		if (!class_exists($this->className)) {
 			$modelName = preg_replace('/Serializer$/', '', $this->className);
-			$model = ClassRegistry::init($modelName);
+
+			// try to load the model name, catch if an exception occurs
+			try {
+				$model = ClassRegistry::init($modelName);
+				$required = array_keys($model->schema());
+			} catch (MissingTableException $e) {
+				$required = array();
+			}
+
 			$serializer = new Serializer();
 			$serializer->rootKey = $modelName;
-			$serializer->required = array_keys($model->schema());
+			$serializer->required = $required;
 			return $serializer;
 		}
 		return new $this->className();

--- a/Test/Case/Lib/SerializerFactoryTest.php
+++ b/Test/Case/Lib/SerializerFactoryTest.php
@@ -38,4 +38,11 @@ class SerializerFactoryTest extends CakeTestCase {
 		$this->assertEquals(array_keys($testTagSchema), $serializer->required);
 		$this->assertEquals('TestTag', $serializer->rootKey);
 	}
+
+	public function testNoModelExistsNorSerializerClassExists() {
+		$factory = new SerializerFactory('TestNoModelExistsWithThisName');
+		$serializer = $factory->generate();
+		$this->assertTrue($serializer instanceof Serializer);
+		$this->assertEquals(array(), $serializer->required);
+	}
 }


### PR DESCRIPTION
Try using Serializers with an Object name that doesn't exist as either a Custom Serializer or as a Model in the app, Exceptions thrown and it crashes. This is a fix.
