### PR TITLE
Fix incorrect missing keys error

### DIFF
--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -298,7 +298,7 @@ class Serializer extends Object {
 		);
 		$jsonData = array();
 		foreach ($whitelistFields as $key) {
-			if (isset($data[$key])) {
+			if (array_key_exists($key, $data)) {
 				$methodName = "serialize_{$key}";
 
 				if (method_exists($this, $methodName)) {


### PR DESCRIPTION
SerializerMissingRequiredException: The following keys were missing from... errors were being triggered when a table field had NULL value. 

This allows for responses such as:

```json

{"videos":[
      {"id":"1","title":"Some video","description":null }
]}
```