### PR TITLE
Requires ext-json To Be Installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
   },
   "require": {
     "php": ">=5.4.0",
-    "composer/installers": "~1.0"
+    "composer/installers": "~1.0",
+    "ext-json": "*"
   },
   "extra": {
     "installer-name": "Serializers"


### PR DESCRIPTION
json_encode and json_decode are used as part of this plugin, therefore they need to be listed as PHP requriement