### PR TITLE
F/sub object errors

### DIFF
--- a/Lib/Error/EmberDataExceptionRenderer.php
+++ b/Lib/Error/EmberDataExceptionRenderer.php
@@ -3,6 +3,8 @@
  * Ensures that all fatal errors are rendered as JSON.
  */
 App::uses('ExceptionRenderer', 'Error');
+App::uses('Inflector', 'Utility');
+App::uses('Hash', 'Utility');
 
 /**
  * EmberDataExceptionRenderer
@@ -91,6 +93,48 @@ class EmberDataExceptionRenderer extends ExceptionRenderer {
 		$this->controller->response->send();
 	}
 
+	public function processErrors($requestData, $errorData, $modelName) {
+		$errorOutputData = array();
+		//debug(compact('requestData', 'errorData', 'topLevelModel'));
+
+		foreach ($requestData[$modelName] as $index => $value) {
+			if (
+				is_array($value)
+				&& !is_int($index)
+				&& array_key_exists($index, $errorData)
+			) {
+				// this is a secondary-model
+				$secondaryModelName = $index;
+				$secondaryModelJsonKey = Inflector::tableize($index);
+				$secondaryModelData[$secondaryModelName] = $value;
+				$secondaryModelError[$secondaryModelName] = $errorData[$secondaryModelName];
+				$secondaryModelErrorOutput = $this->processErrors($secondaryModelData, $secondaryModelError, $secondaryModelName);
+
+				$errorOutputData[$secondaryModelJsonKey] = $secondaryModelErrorOutput;
+			} elseif (
+				is_int($index)
+			) {
+				$errorOutputData[$index] = array();
+				// this is looping through a secondary model
+				foreach ($errorData[$modelName] as $keyWithError => $errorsForObjectAtKey) {
+					foreach($errorsForObjectAtKey as $fieldWithError => $errorMessages) {
+						// spec can't handle multiple failures per field, so only return the first found.
+						$errorOutputData[$index][$fieldWithError] = reset($errorMessages);
+					}
+				}
+			} elseif (
+				array_key_exists($index, $errorData)
+			) {
+				 // spec can't handle multiple failures per field, so only return the first found.
+				$errorOutputData[$index] = reset($errorData[$index]);
+			} else {
+				// this field for a top level model doesn't have errors
+			}
+		}
+
+		return $errorOutputData;
+	}
+
 	/**
 	 * Helper method used to generate extra debugging data into the error template
 	 *
@@ -108,11 +152,51 @@ class EmberDataExceptionRenderer extends ExceptionRenderer {
 
 		if ($viewVars['error'] instanceof ValidationFailedJsonApiException) {
 			if (!empty($viewVars['error'])) {
-				$data = $viewVars['error']->getDetail();
-				foreach ($data as $errorVar => $errorDescrptions) {
-					$data[$errorVar] = $errorDescrptions[0];
+				$errorData = $viewVars['error']->getDetail();
+				$requestData = $viewVars['error']->getRequestData();
+
+				//debug($errorData);
+				//debug($requestData);
+
+				$topLevelModel = key($requestData);
+				$errorOutputData = $this->processErrors($requestData, $errorData, $topLevelModel);
+
+				foreach ($errorData as $fieldWithError => $errorMessages) {
+					$firstErrorMessage = reset($errorMessages);
+					// this is an error of a sub model attempted to be saved at the same
+					// time as the primary model if error messages is an array of arrays
+					if (is_array($firstErrorMessage)) {
+						$secondaryModelName = Inflector::tableize($fieldWithError);
+
+						// // if the number of models fialed
+						$numberOfModelsFailedValidation = count($errorMessages);
+						end($errorMessages);
+						$finalKey = (key($errorMessages) + 1);
+
+						reset($errorMessages);
+
+						// if the final key in our array of error messages is different
+						// from the number of models that failed validation
+						// we need to populated an empty object at each and every
+						// instance of the secondary model that exists on the data passed
+						// to the save method
+
+						$errorOutputData[$secondaryModelName] = array_fill(0, $finalKey, new stdClass());
+
+						foreach ($errorMessages as $indexOfError => $fieldErrors) {
+							foreach ($fieldErrors as $fieldName => $errorMessages) {
+								if ($errorOutputData[$secondaryModelName][$indexOfError] instanceof stdClass) {
+									$errorOutputData[$secondaryModelName][$indexOfError] = array();
+								}
+								$errorOutputData[$secondaryModelName][$indexOfError][$fieldName] = Hash::get($errorMessages, "0");
+							}
+						}
+					} else {
+						$errorOutputData[$fieldWithError] = $firstErrorMessage;
+					}
 				}
-				return $data;
+
+				return $errorOutputData;
 			}
 		} elseif ($viewVars['error'] instanceof StandardJsonApiExceptions) {
 			if (!empty($viewVars['error'])) {

--- a/Lib/Error/StandardJsonApiExceptions.php
+++ b/Lib/Error/StandardJsonApiExceptions.php
@@ -225,10 +225,18 @@ class ForbiddenByPermissionsException extends StandardJsonApiExceptions {
 class ValidationFailedJsonApiException extends StandardJsonApiExceptions {
 
 	/**
+	 * The request data passed to the model save method
+	 *
+	 * @var array
+	 */
+	public $requestData = array();
+
+	/**
 	 * Constructs a new instance of the ValidationFailedJsonApiException
 	 *
 	 * @param string $title The title of the exception.
-	 * @param string $detail A detailed human readable message.
+	 * @param array $detail The validation errors returned from $this->ModelName->invalidFields().
+	 * @param array $requestData The request data passed to the controller, ie. $this->request->data
 	 * @param int $code The http status code of the error.
 	 * @param string $href A URI that MAY yield further details about this particular occurrence of the problem.
 	 * @param string $id A unique identifier for this particular occurrence of the problem.
@@ -236,11 +244,22 @@ class ValidationFailedJsonApiException extends StandardJsonApiExceptions {
 	public function __construct(
 		$title = 'Validation Failed',
 		array $detail = array(),
+		array $requestData = array(),
 		$code = 422,
 		$href = null,
 		$id = null
 	) {
+		$this->requestData = $requestData;
 		parent::__construct($title, $detail, $code, $href, $id);
+	}
+
+	/**
+	 * return the id for this Exception
+	 *
+	 * @return string
+	 */
+	public function getRequestData() {
+		return $this->requestData;
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ This does two things:
 
 * Errors and Exceptions get output as correctly formatted JSON
 * Allows the use of Custom Exceptions that match Ember Data exceptions for error cases
+* The error format for validation errors follows the format suggested by [DS.Errors](http://emberjs.com/api/data/classes/DS.Errors.html)
 
 ## Custom Bake Templates ##
 

--- a/Test/Case/Lib/Error/ExceptionsTest.php
+++ b/Test/Case/Lib/Error/ExceptionsTest.php
@@ -158,30 +158,6 @@ class StandardJsonApiExceptionsTest extends CakeTestCase {
 			),
 
 			array(
-				'ValidationFailedJsonApiException',
-				array(
-					'title' => 'Validation Failed',
-					'detail' => array(
-						'name' => 'invalid name',
-						'boolean' => 'invalid boolean field',
-					),
-					'code' => 422,
-					'href' => '/right/here/right/now',
-					'id' => 'a14d2c0c-c9d1-11e4-ba2d-080027506c76',
-				),
-				array(
-					'getTitle' => 'Validation Failed',
-					'getDetail' => array(
-						'name' => 'invalid name',
-						'boolean' => 'invalid boolean field',
-					),
-					'getCode' => 422,
-					'getHref' => '/right/here/right/now',
-					'getId' => 'a14d2c0c-c9d1-11e4-ba2d-080027506c76',
-				),
-			),
-
-			array(
 				'ModelSaveFailedJsonApiException',
 				array(
 					'title' => 'Model Save Failed',
@@ -325,6 +301,7 @@ class StandardJsonApiExceptionsTest extends CakeTestCase {
 				array(
 					'getTitle' => 'Validation Failed',
 					'getDetail' => array(),
+					'getRequestData' => array(),
 					'getCode' => 422,
 					'getHref' => null,
 					'getId' => null,
@@ -361,6 +338,85 @@ class StandardJsonApiExceptionsTest extends CakeTestCase {
 					'getCode' => 502,
 					'getHref' => null,
 					'getId' => null,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Confirm that all Exception constructors set provided args into the
+	 * correct properties. As a side-effect, also tests the getter methods
+	 * for all properties.
+	 *
+	 * @param string $class The Exception class name to instantiate.
+	 * @param	array	$args An array of args to pass to the constructor method.
+	 * @param array $expected The expected properties of the Exception class
+	 * @param string $msg Optional PHPUnit error message when the assertion fails.
+	 * @return void
+	 * @dataProvider provideTestValidationConstructorsArgs
+	 */
+	public function testValidationExceptionConstructor($class, $args, $expected, $msg = 'The method ::%1$s() is expected to return the value `%2$s`.') {
+		extract($args);
+
+		$e = new $class($title, $detail, $requestData, $code, $href, $id);
+		foreach ($expected as $method => $value) {
+
+			if (is_array($value)) {
+				$this->assertEquals(
+					$value,
+					$e->{$method}()
+				);
+			} else {
+				$this->assertEquals(
+					$value,
+					$e->{$method}(),
+					sprintf($msg, $method, $value)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Provide sets of [exception class name, constructor args, expected, msg] sets
+	 * to testValidationExceptionConstructor();
+	 *
+	 * @return array data inputs to testValidationExceptionConstructor
+	 */
+	public function provideTestValidationConstructorsArgs() {
+		return array(
+			array(
+				'ValidationFailedJsonApiException',
+				array(
+					'title' => 'Validation Failed',
+					'detail' => array(
+						'name' => 'invalid name',
+						'boolean' => 'invalid boolean field',
+					),
+					'requestData' => array(
+						'User' => array(
+							'name' => 'invalid name',
+							'boolean' => 'invalid boolean field',
+						),
+					),
+					'code' => 422,
+					'href' => '/right/here/right/now',
+					'id' => 'a14d2c0c-c9d1-11e4-ba2d-080027506c76',
+				),
+				array(
+					'getTitle' => 'Validation Failed',
+					'getDetail' => array(
+						'name' => 'invalid name',
+						'boolean' => 'invalid boolean field',
+					),
+					'getRequestData' => array(
+						'User' => array(
+							'name' => 'invalid name',
+							'boolean' => 'invalid boolean field',
+						),
+					),
+					'getCode' => 422,
+					'getHref' => '/right/here/right/now',
+					'getId' => 'a14d2c0c-c9d1-11e4-ba2d-080027506c76',
 				),
 			),
 		);


### PR DESCRIPTION
:warning: WIP :warning: 

PR to add support for sub object errors and update format to match [DS.Errors](http://emberjs.com/api/data/classes/DS.Errors.html).

There are breaking changes in PR, as error messages are no longer strings but instead an array of strings to match the format of DS.Errors.

Closes #100
Closes #101